### PR TITLE
Fixing a bug when parsing the URL for GET with parameters

### DIFF
--- a/helpers/application_helper.rb
+++ b/helpers/application_helper.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'uri'
+
 module ApplicationHelper
 
   def h(text)
@@ -301,7 +305,7 @@ module ApplicationHelper
 
   def process_http_verb
     log_incoming_request if ENV['REQUEST_LOGGING']
-    url = request.fullpath.sub!(/^\//, '')
+    url = URI.parse(request.fullpath).path.sub(%r{^/}, '')
     @mock_response = process_url(url, request.request_method, ENV['TEST_ENV'])
 
     if ENV['LATENCY']

--- a/helpers/script_helper.rb
+++ b/helpers/script_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
   def get_current_request_db_row
     if !defined? @current_request_db_data
       @current_request_db_data = nil
-      url = request.fullpath.sub!(/^\//, '')
+      url = URI.parse(request.fullpath).path.sub!(/^\//, '')
       query = Mockdata.where(mock_request_url: url,
                              mock_http_verb: request.request_method,
                              mock_environment: ENV['TEST_ENV'],


### PR DESCRIPTION
I have found a problem when requesting a URL like this:

`curl -X GET "localhost:9293/some_path?parameter=1`

The regular expression is not enough, because doesn't wipe the `?parameter=1` and does not match.

This is a quick fix for that.

cc: @mvemjsun 